### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ pip install pytest
 pytest tests/ -v
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ark-forge-mcp-eu-ai-act).
+
 ## Usage Examples
 
 Once connected via MCP (see integration below), call tools by name.


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ark-forge-mcp-eu-ai-act).